### PR TITLE
Adding support for multiple stats commands run separated by interval [linux]

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ In order to gather the elasticsearch config and logs you must run the script on 
     -n  On a host with multiple nodes, specify the node name to gather data for. Value should match node.name as defined in elasticsearch.yml
     -o  Script output directory (optional, defaults to support-diagnostics.[timestamp].[hostname])
     -nc Disable compression (optional)
+    -r  Collect stats r times (optional, in conjunction with -i , defaults to 1)
+    -i  Interval in seconds between stats collections (optional, in conjunction with -r , defaults to 30 secs)
 
 ### Running on Windows
 

--- a/bin/support-diagnostics.sh
+++ b/bin/support-diagnostics.sh
@@ -208,7 +208,7 @@ echo "Getting _cluster/settings"
 curl -XGET "$eshost/_cluster/settings?pretty" >> $outputdir/cluster_settings.json 2> /dev/null
 
 
-#grab stats#
+#grab stats
 #execute multiple times if $repeat is > 1
 i=1
 while [ $i -le $repeat ]

--- a/bin/support-diagnostics.sh
+++ b/bin/support-diagnostics.sh
@@ -14,6 +14,8 @@ timestamp=$(date +"%Y%m%d-%H%M%S")
 # set defaults
 eshost="localhost:9200"
 targetNode='_local'
+repeat=1
+interval=30
 
 # pick up command line options
 while [ $# -gt 0 ]
@@ -30,12 +32,16 @@ In order to gather the elasticsearch config and logs you must run this on a node
   -n  On a host with multiple nodes, specify the node name to gather data for. Value should match node.name as defined in elasticsearch.yml
   -o  Script output directory (optional, defaults to ./support-diagnostics.[timestamp].[hostname])
   -nc Disable compression (optional)
+  -r  Collect stats r times (optional, in conjunction with -i , defaults to 1)
+  -i  Interval in seconds between stats collections (optional, in conjunction with -r , defaults to 30 secs)
 EOM
             exit 1;;
         -H)  eshost=$2;;
         -n)  targetNode=$2;;
         -nc) nocompression=true;;
         -o)  outputdir=$2;;
+        -r)  repeat=$2;;
+        -i)  interval=$2;;
 
     esac
     shift
@@ -184,7 +190,11 @@ else
 fi
 
 
+
 #api calls that work with all versions
+
+#grab settings
+echo "Collecting version, mappings, settings"
 echo "Getting version"
 curl -XGET "$eshost" >> $outputdir/version.json 2> /dev/null
 
@@ -197,88 +207,112 @@ curl -XGET "$eshost/_settings?pretty" >> $outputdir/settings.json 2> /dev/null
 echo "Getting _cluster/settings"
 curl -XGET "$eshost/_cluster/settings?pretty" >> $outputdir/cluster_settings.json 2> /dev/null
 
-echo "Getting _cluster/state"
-curl -XGET "$eshost/_cluster/state?pretty" >> $outputdir/cluster_state.json 2> /dev/null
 
-echo "Getting _cluster/stats"
-curl -XGET "$eshost/_cluster/stats?pretty&human" >> $outputdir/cluster_stats.json 2> /dev/null
+#grab stats#
+#execute multiple times if $repeat is > 1
+i=1
+while [ $i -le $repeat ]
+    do
+        if [ $i -eq 1 ]
+            then
+                idx=""
+            else
+                idx=".$i"
+        fi
 
-echo "Getting _cluster/health"
-curl -XGET "$eshost/_cluster/health?pretty" >> $outputdir/cluster_health.json 2> /dev/null
+        echo "Collecting stats $i/$repeat"
 
-echo "Getting _cluster/pending_tasks"
-curl -XGET "$eshost/_cluster/pending_tasks?pretty&human" >> $outputdir/cluster_pending_tasks.json 2> /dev/null
+        date=`date  +%Y-%m-%d_%H_%M_%S`
+        echo "Getting _cluster/state"
+        curl -XGET "$eshost/_cluster/state?pretty" >> $outputdir/cluster_state.json$idx.$date 2> /dev/null
 
-echo "Getting _count"
-curl -XGET "$eshost/_count?pretty" >> $outputdir/count.json 2> /dev/null
+        echo "Getting _cluster/stats"
+        curl -XGET "$eshost/_cluster/stats?pretty&human" >> $outputdir/cluster_stats.json$idx.$date 2> /dev/null
 
-echo "Getting nodes info"
-curl -XGET "$eshost/_nodes/?all&pretty&human" >> $outputdir/nodes.json 2> /dev/null
+        echo "Getting _cluster/health"
+        curl -XGET "$eshost/_cluster/health?pretty" >> $outputdir/cluster_health.json$idx.$date 2> /dev/null
 
-echo "Getting _nodes/hot_threads"
-curl -XGET "$eshost/_nodes/hot_threads?threads=10" >> $outputdir/nodes_hot_threads.txt 2> /dev/null
+        echo "Getting _cluster/pending_tasks"
+        curl -XGET "$eshost/_cluster/pending_tasks?pretty&human" >> $outputdir/cluster_pending_tasks.json$idx.$date 2> /dev/null
 
+        echo "Getting _count"
+        curl -XGET "$eshost/_count?pretty" >> $outputdir/count.json$idx.$date 2> /dev/null
 
-#api calls that only work with 0.90
-if [[ $esVersion =~ 0.90.* ]]; then
-    echo "Getting _nodes/stats"
-    curl -XGET "$eshost/_nodes/stats?all&pretty&human" >> $outputdir/nodes_stats.json 2> /dev/null
+        echo "Getting nodes info"
+        curl -XGET "$eshost/_nodes/?all&pretty&human" >> $outputdir/nodes.json$idx.$date 2> /dev/null
 
-    echo "Getting indices stats"
-    curl -XGET "$eshost/_stats?all&pretty&human" >> $outputdir/indices_stats.json 2> /dev/null
-
-#api calls that only work with 1.0+
-else
-    echo "Getting _nodes/stats"
-    curl -XGET "$eshost/_nodes/stats?pretty&human" >> $outputdir/nodes_stats.json 2> /dev/null
-
-    echo "Getting indices stats"
-    curl -XGET "$eshost/_stats?pretty&human" >> $outputdir/indices_stats.json 2> /dev/null
-
-    echo "Getting _cat/allocation"
-    curl -XGET "$eshost/_cat/allocation?v" >> $outputdir/allocation.txt 2> /dev/null
-
-    echo "Getting _cat/plugins"
-    curl -XGET "$eshost/_cat/plugins?v" >> $outputdir/plugins.txt 2> /dev/null
-
-    echo "Getting _cat/shards"
-    curl -XGET "$eshost/_cat/shards?v" >> $outputdir/cat_shards.txt 2> /dev/null
-
-    #api calls that only work with 1.1+
-    if [[ ! $esVersion =~ 1.0.* ]]; then
-        echo "Getting _recovery"
-        curl -XGET "$eshost/_recovery?detailed&pretty&human" >> $outputdir/recovery.json 2> /dev/null
-    #api calls that only work with 1.0
-    else
-        echo "Getting _cat/recovery"
-        curl -XGET "$eshost/_cat/recovery?v" >> $outputdir/cat_recovery.txt 2> /dev/null
-    fi
-fi
+        echo "Getting _nodes/hot_threads"
+        curl -XGET "$eshost/_nodes/hot_threads?threads=10" >> $outputdir/nodes_hot_threads.txt$idx.$date 2> /dev/null
 
 
-echo "Running netstat"
-if [ "$(uname)" == "Darwin" ]; then
-    netstat -an >> $outputdir/netstat.txt
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    netstat -anp >> $outputdir/netstat.txt
-fi
+        #api calls that only work with 0.90
+        if [[ $esVersion =~ 0.90.* ]]; then
+            echo "Getting _nodes/stats"
+            curl -XGET "$eshost/_nodes/stats?all&pretty&human" >> $outputdir/nodes_stats.json$idx.$date 2> /dev/null
 
-echo "Running top"
-if [ "$(uname)" == "Darwin" ]; then
-    top -l 1 >> $outputdir/top.txt
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    top -b -n1 >> $outputdir/top.txt
-fi
+            echo "Getting indices stats"
+            curl -XGET "$eshost/_stats?all&pretty&human" >> $outputdir/indices_stats.json$idx.$date 2> /dev/null
 
-echo "Running top with threads (Linux only)"
-if [ "$(uname)" == "Darwin" ]; then
-    echo "This is a Mac.  Not running top -H."
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    top -b -n1 -H >> $outputdir/top_threads.txt
-fi
+        #api calls that only work with 1.0+
+        else
+            echo "Getting _nodes/stats"
+            curl -XGET "$eshost/_nodes/stats?pretty&human" >> $outputdir/nodes_stats.json$idx.$date 2> /dev/null
 
-echo "Running ps"
-ps -ef | grep elasticsearch >> $outputdir/elasticsearch-process.txt
+            echo "Getting indices stats"
+            curl -XGET "$eshost/_stats?pretty&human" >> $outputdir/indices_stats.json$idx.$date 2> /dev/null
+
+            echo "Getting _cat/allocation"
+            curl -XGET "$eshost/_cat/allocation?v" >> $outputdir/allocation.txt$idx.$date 2> /dev/null
+
+            echo "Getting _cat/plugins"
+            curl -XGET "$eshost/_cat/plugins?v" >> $outputdir/plugins.txt$idx.$date 2> /dev/null
+
+            echo "Getting _cat/shards"
+            curl -XGET "$eshost/_cat/shards?v" >> $outputdir/cat_shards.txt$idx.$date 2> /dev/null
+
+            #api calls that only work with 1.1+
+            if [[ ! $esVersion =~ 1.0.* ]]; then
+                echo "Getting _recovery"
+                curl -XGET "$eshost/_recovery?detailed&pretty&human" >> $outputdir/recovery.json$idx.$date 2> /dev/null
+            #api calls that only work with 1.0
+            else
+                echo "Getting _cat/recovery"
+                curl -XGET "$eshost/_cat/recovery?v" >> $outputdir/cat_recovery.txt$idx.$date 2> /dev/null
+            fi
+        fi
+
+
+        echo "Running netstat"
+        if [ "$(uname)" == "Darwin" ]; then
+            netstat -an >> $outputdir/netstat$idx.$date.txt
+        elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+            netstat -anp >> $outputdir/netstat$idx.$date.txt
+        fi
+
+        echo "Running top"
+        if [ "$(uname)" == "Darwin" ]; then
+            top -l 1 >> $outputdir/top$idx.$date.txt
+        elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+            top -b -n1 >> $outputdir/top$idx.$date.txt
+        fi
+
+        echo "Running top with threads (Linux only)"
+        if [ "$(uname)" == "Darwin" ]; then
+            echo "This is a Mac.  Not running top -H."
+        elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+            top -b -n1 -H >> $outputdir/top_threads$idx.$date.txt
+        fi
+
+        echo "Running ps"
+        ps -ef | grep elasticsearch >> $outputdir/elasticsearch-process$idx.$date.txt
+        i=$[i+1]
+        if [ $i -lt $repeat ]
+            then
+                echo "Sleeping $interval second(s)..."
+                sleep $interval
+        fi
+
+done
 
 
 echo "Output complete.  Creating tarball."


### PR DESCRIPTION
It would be interesting to collect the info from stats/state commands in a repeated way (e.g. 10 times with 600 seconds interval), for troubleshooting and monitoring reasons.

Settings, mappings and static values in general are not in the loop of course.

Subsequent captured files are renamed .2, .3 and so on.

This would be in the bigger picture of processing and sending captured data in ES instance then display nice charts with Kibana

Sample output

```
abonuccelli@w530 ~/IdeaProjects/elasticsearch-support-diagnostics/bin $ ./support-diagnostics.sh  -H miami:9200 -r 3 -i 1
Getting your configuration from the elasticsearch API

ERROR: Could not determine config directory location from api. Please add your config directory to the support-diagnostics.w530._local.20141130-021900.tar or to your ticket

Collecting version, mappings, settings
Getting version
Getting _mapping
Getting _settings
Getting _cluster/settings
Collecting stats 1/3
Getting _cluster/state
Getting _cluster/stats
Getting _cluster/health
Getting _cluster/pending_tasks
Getting _count
Getting nodes info
Getting _nodes/hot_threads
Getting _nodes/stats
Getting indices stats
Getting _cat/allocation
Getting _cat/plugins
Getting _cat/shards
Getting _recovery
Running netstat
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
Running top
Running top with threads (Linux only)
Running ps
Sleeping 1 seconds...
Collecting stats 2/3
Getting _cluster/state
Getting _cluster/stats
Getting _cluster/health
Getting _cluster/pending_tasks
Getting _count
Getting nodes info
Getting _nodes/hot_threads
Getting _nodes/stats
Getting indices stats
Getting _cat/allocation
Getting _cat/plugins
Getting _cat/shards
Getting _recovery
Running netstat
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
Running top
Running top with threads (Linux only)
Running ps
Collecting stats 3/3
Getting _cluster/state
Getting _cluster/stats
Getting _cluster/health
Getting _cluster/pending_tasks
Getting _count
Getting nodes info
Getting _nodes/hot_threads
Getting _nodes/stats
Getting indices stats
Getting _cat/allocation
Getting _cat/plugins
Getting _cat/shards
Getting _recovery
Running netstat
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
Running top
Running top with threads (Linux only)
Running ps
Output complete.  Creating tarball.

Done. Created support-diagnostics.w530._local.20141130-021900.tar.gz

abonuccelli@w530 ~/IdeaProjects/elasticsearch-support-diagnostics/bin $ cd support-diagnostics.w530._local.20141130-021900/
abonuccelli@w530 ~/IdeaProjects/elasticsearch-support-diagnostics/bin/support-diagnostics.w530._local.20141130-021900 $ ls
allocation.txt.2014-11-30_02_19_21                cluster_state.json.2.2014-11-30_02_19_47         mapping.json                                 plugins.txt.2.2014-11-30_02_19_47
allocation.txt.2.2014-11-30_02_19_47              cluster_state.json.3.2014-11-30_02_20_11         netstat.2014-11-30_02_19_21.txt              plugins.txt.3.2014-11-30_02_20_11
allocation.txt.3.2014-11-30_02_20_11              cluster_stats.json.2014-11-30_02_19_21           netstat.2.2014-11-30_02_19_47.txt            recovery.json.2014-11-30_02_19_21
cat_shards.txt.2014-11-30_02_19_21                cluster_stats.json.2.2014-11-30_02_19_47         netstat.3.2014-11-30_02_20_11.txt            recovery.json.2.2014-11-30_02_19_47
cat_shards.txt.2.2014-11-30_02_19_47              cluster_stats.json.3.2014-11-30_02_20_11         nodes_hot_threads.txt.2014-11-30_02_19_21    recovery.json.3.2014-11-30_02_20_11
cat_shards.txt.3.2014-11-30_02_20_11              count.json.2014-11-30_02_19_21                   nodes_hot_threads.txt.2.2014-11-30_02_19_47  settings.json
cluster_health.json.2014-11-30_02_19_21           count.json.2.2014-11-30_02_19_47                 nodes_hot_threads.txt.3.2014-11-30_02_20_11  top.2014-11-30_02_19_21.txt
cluster_health.json.2.2014-11-30_02_19_47         count.json.3.2014-11-30_02_20_11                 nodes.json.2014-11-30_02_19_21               top.2.2014-11-30_02_19_47.txt
cluster_health.json.3.2014-11-30_02_20_11         elasticsearch-process.2014-11-30_02_19_21.txt    nodes.json.2.2014-11-30_02_19_47             top.3.2014-11-30_02_20_11.txt
cluster_pending_tasks.json.2014-11-30_02_19_21    elasticsearch-process.2.2014-11-30_02_19_47.txt  nodes.json.3.2014-11-30_02_20_11             top_threads.2014-11-30_02_19_21.txt
cluster_pending_tasks.json.2.2014-11-30_02_19_47  elasticsearch-process.3.2014-11-30_02_20_11.txt  nodes_stats.json.2014-11-30_02_19_21         top_threads.2.2014-11-30_02_19_47.txt
cluster_pending_tasks.json.3.2014-11-30_02_20_11  indices_stats.json.2014-11-30_02_19_21           nodes_stats.json.2.2014-11-30_02_19_47       top_threads.3.2014-11-30_02_20_11.txt
cluster_settings.json                             indices_stats.json.2.2014-11-30_02_19_47         nodes_stats.json.3.2014-11-30_02_20_11       version.json
cluster_state.json.2014-11-30_02_19_21            indices_stats.json.3.2014-11-30_02_20_11         plugins.txt.2014-11-30_02_19_21
```

